### PR TITLE
setup.py: remove numpy from setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or
     setup(**metadata)
 else:
     setup(
-        setup_requires=['numpy'],
         install_requires=['numpy'],
         cmdclass={'build_ext': BuildExt},
         ext_modules=[Extension('pyxdameraulevenshtein', ['pyxdameraulevenshtein/pyxdameraulevenshtein.c'])],


### PR DESCRIPTION
8 days ago was released Numpy v1.16.0rc1 and is used in the setup
compilation. v1.16.0rc1 is not compatible with the previous version
compiled versions of numpy itself

ref: https://github.com/pypa/pip/issues/410
ref: https://pip.pypa.io/en/stable/reference/pip_install/#hash-checking-mode

fix gfairchild/pyxDamerauLevenshtein#14