### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (e.g., 1.8.0)'
+        description: "Release version (e.g., 1.8.0)"
         required: true
-        default: ''
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -24,11 +24,11 @@ jobs:
       matrix:
         # Github Actions doesn't support pairing matrix values together, let's improvise
         buildplat:
-        - [ubuntu-latest, manylinux_x86_64]
-        - [ubuntu-latest, musllinux_x86_64]
-        - [macos-13, macosx_*]
-        - [windows-latest, win_amd64]
-        python: ['cp39', 'cp310', 'cp311', 'cp312', 'cp313']
+          - [ubuntu-latest, manylinux_x86_64]
+          - [ubuntu-latest, musllinux_x86_64]
+          - [macos-13, macosx_*]
+          - [windows-latest, win_amd64]
+        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
           python3 -m pip install --upgrade pip
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v3.1.0
         env:
           CIBW_BEFORE_BUILD: pip install -r requirements.txt
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
@@ -61,11 +61,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-          
+          python-version: "3.10"
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -74,7 +74,7 @@ jobs:
       - name: Build sdist
         run: |
           python setup.py sdist
-          
+
       - uses: actions/upload-artifact@v4
         with:
           name: sdist
@@ -86,11 +86,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -114,20 +114,20 @@ jobs:
           files: release_files/*
           body: |
             # pyxDamerauLevenshtein ${{ github.event.inputs.version }}
-            
-            This release includes built wheels for Python 3.9, 3.10, 3.11, 3.12, and 3.13 on the following platforms:
+
+            This release includes built wheels for Python 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14 on the following platforms:
             - Linux (manylinux, musllinux)
             - macOS
             - Windows
-            
+
             And a source distribution for manual installation.
-            
+
             ## Installation
-            
+
             ```
             pip install pyxDamerauLevenshtein
             ```
-            
+
             For more information, see the [README](https://github.com/lanl/pyxDamerauLevenshtein/blob/main/README.md).
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g., 1.8.0)"
+        description: 'Release version (e.g., 1.8.0)'
         required: true
-        default: ""
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -24,11 +24,11 @@ jobs:
       matrix:
         # Github Actions doesn't support pairing matrix values together, let's improvise
         buildplat:
-          - [ubuntu-latest, manylinux_x86_64]
-          - [ubuntu-latest, musllinux_x86_64]
-          - [macos-13, macosx_*]
-          - [windows-latest, win_amd64]
-        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
+        - [ubuntu-latest, manylinux_x86_64]
+        - [ubuntu-latest, musllinux_x86_64]
+        - [macos-13, macosx_*]
+        - [windows-latest, win_amd64]
+        python: ['cp39', 'cp310', 'cp311', 'cp312', 'cp313', 'cp314']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -61,11 +61,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
+        
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
-
+          python-version: '3.10'
+          
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -74,7 +74,7 @@ jobs:
       - name: Build sdist
         run: |
           python setup.py sdist
-
+          
       - uses: actions/upload-artifact@v4
         with:
           name: sdist
@@ -86,11 +86,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
+        
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: '3.10'
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -114,20 +114,20 @@ jobs:
           files: release_files/*
           body: |
             # pyxDamerauLevenshtein ${{ github.event.inputs.version }}
-
+            
             This release includes built wheels for Python 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14 on the following platforms:
             - Linux (manylinux, musllinux)
             - macOS
             - Windows
-
+            
             And a source distribution for manual installation.
-
+            
             ## Installation
-
+            
             ```
             pip install pyxDamerauLevenshtein
             ```
-
+            
             For more information, see the [README](https://github.com/lanl/pyxDamerauLevenshtein/blob/main/README.md).
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - 3.11
   - 3.12
   - 3.13
+  - 3.14
 
 before_install:
   - pip install --upgrade pip setuptools wheel

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ metadata = dict(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Topic :: Text Processing :: Linguistic',


### PR DESCRIPTION
## Description

- Update [`cibuildwheel`](https://cibuildwheel.pypa.io/en/stable/changelog/#v310) to version 3.1.0 in github workflow to support the wheel building of Python 3.14
- Add 3.14 in other files mentioned Python version

## Result

- The demo action run with Python 3.14: https://github.com/harui2019/pyxDamerauLevenshtein/actions/runs/17423996752
- Release here: https://github.com/harui2019/pyxDamerauLevenshtein/releases